### PR TITLE
フォーマット後のテキストを設定する関数を追加

### DIFF
--- a/py_binding/py_miz_controller.cpp
+++ b/py_binding/py_miz_controller.cpp
@@ -368,7 +368,9 @@ PYBIND11_MODULE(py_miz_controller, m)
     .def_property_readonly("column_number", &ASTToken::GetColumnNumber)
     .def_property_readonly("text", &ASTToken::GetText)
     .def_property_readonly("token_type", &ASTToken::GetTokenType)
-    .def_property_readonly("ref_token", &ASTToken::GetRefToken, py::return_value_policy::reference);
+    .def_property_readonly("ref_token", &ASTToken::GetRefToken, py::return_value_policy::reference)
+    .def("set_formatted_text", &ASTToken::SetFormattedText)
+    .def_property_readonly("formatted_text", &ASTToken::GetFormattedText);
 
   py::class_<UnknownToken,ASTToken, PyUnknownToken, std::shared_ptr<UnknownToken>>(m, "UnknownToken");
 

--- a/src/component/ast_token.hpp
+++ b/src/component/ast_token.hpp
@@ -37,6 +37,8 @@ class ASTToken : public ASTElement
     virtual std::string_view GetText() const = 0;
     virtual TOKEN_TYPE GetTokenType() const = 0;
     virtual IdentifierToken* GetRefToken() const = 0;
+    void SetFormattedText(std::string_view text) { formatted_text_ = text; }
+    std::string_view GetFormattedText() const { return formatted_text_; };
 
     // operations
     void ToJson(nlohmann::json& json) const override;
@@ -45,6 +47,7 @@ class ASTToken : public ASTElement
     size_t id_ = SIZE_MAX;
     size_t line_number_;
     size_t column_number_;
+    std::string formatted_text_;
 };
 
 class UnknownToken : public ASTToken


### PR DESCRIPTION
フォーマッターでテキストのチェックをした時に、正しいテキストを設定・取得する関数を追加

close #39 